### PR TITLE
Fold @param and @return KDoc tags into the description prose

### DIFF
--- a/src/commonMain/kotlin/kodvent/boundsearch/BoundSearch.kt
+++ b/src/commonMain/kotlin/kodvent/boundsearch/BoundSearch.kt
@@ -11,16 +11,9 @@ package kodvent.boundsearch
  * Finds the partition point in the range `[[fromIndex], [toIndex])` where a predicate transitions from `true` to `false`.
  *
  * This function uses binary search to efficiently locate the first index in the range where the [predicate]
- * returns `false`. The predicate must be monotonic: if it returns `false` for some index, it must return `false`
- * for all later indices in the range.
- *
- * @param fromIndex The start of the range (inclusive). Must not be greater than [toIndex].
- * @param toIndex The end of the range (exclusive). Must not be less than [fromIndex].
- * @param predicate A monotonic predicate function that takes an index and returns `true` for all indices
- *                  before the partition point and `false` from the partition point onwards.
- *
- * @return The partition point: the first index where [predicate] returns `false`, or [toIndex] if [predicate]
- *         is `true` for all indices in the range.
+ * returns `false`, or [toIndex] if [predicate] is `true` for all indices. The predicate must be monotonic:
+ * if it returns `false` for some index, it must return `false` for all later indices in the range.
+ * [fromIndex] is the inclusive start of the range and [toIndex] the exclusive end.
  *
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
  *
@@ -54,16 +47,9 @@ public inline fun partitionPoint(fromIndex: Int, toIndex: Int, predicate: (Int) 
  * Finds the partition point in the range `[[fromIndex], [toIndex])` where a predicate transitions from `true` to `false`.
  *
  * This function uses binary search to efficiently locate the first index in the range where the [predicate]
- * returns `false`. The predicate must be monotonic: if it returns `false` for some index, it must return `false`
- * for all later indices in the range.
- *
- * @param fromIndex The start of the range (inclusive). Must not be greater than [toIndex].
- * @param toIndex The end of the range (exclusive). Must not be less than [fromIndex].
- * @param predicate A monotonic predicate function that takes an index and returns `true` for all indices
- *                  before the partition point and `false` from the partition point onwards.
- *
- * @return The partition point: the first index where [predicate] returns `false`, or [toIndex] if [predicate]
- *         is `true` for all indices in the range.
+ * returns `false`, or [toIndex] if [predicate] is `true` for all indices. The predicate must be monotonic:
+ * if it returns `false` for some index, it must return `false` for all later indices in the range.
+ * [fromIndex] is the inclusive start of the range and [toIndex] the exclusive end.
  *
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
  *
@@ -87,17 +73,10 @@ public inline fun partitionPoint(fromIndex: Long, toIndex: Long, predicate: (Lon
 
 /**
  * Finds the argument that maximizes [f] on the interval [[left], [right]]
- * using ternary search.
+ * using ternary search, with precision up to `1e-9`.
  *
  * The function [f] must be **unimodal** on the given interval,
  * i.e., strictly increasing then strictly decreasing.
- *
- * @param left the left bound of the search interval.
- * @param right the right bound of the search interval; must be >= [left].
- * @param f the unimodal function to maximize.
- *
- * @return the argument `x` in [[left], [right]] at which [f] attains its maximum,
- *         with precision up to `1e-9`.
  *
  * @throws IllegalArgumentException if [left] > [right].
  *

--- a/src/commonMain/kotlin/kodvent/collections/Collections.kt
+++ b/src/commonMain/kotlin/kodvent/collections/Collections.kt
@@ -10,22 +10,18 @@ package kodvent.collections
 import kodvent.boundsearch.partitionPoint
 
 /**
- * Finds the first position in this sorted list or its range where [element] could be inserted while maintaining sorted order.
+ * Finds the first position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
+ * [toIndex] (exclusive), which default to 0 and the list size respectively — where [element] could be
+ * inserted while maintaining sorted order.
  * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of its elements,
  * otherwise the result is undefined.
  *
  * This function implements the lower bound algorithm: it returns the index of the first element that is NOT less than [element].
  * If all elements are less than [element], returns the end index ([toIndex]).
  * If the list contains multiple elements equal to [element], returns the index of the first such element.
+ * Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * `null` value is considered to be less than any non-null value.
- *
- * @param element the element to search for.
- * @param fromIndex the start of the range (inclusive) to search in, 0 by default.
- * @param toIndex the end of the range (exclusive) to search in, size of this list by default.
- *
- * @return the index of the first element that is greater than or equal to [element], or [toIndex] if all elements are less than [element].
- *         Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -41,7 +37,9 @@ public fun <T : Comparable<T>> List<T?>.lowerBound(element: T?, fromIndex: Int =
 }
 
 /**
- * Finds the first position in this sorted list or its range where [element] could be inserted while maintaining sorted order.
+ * Finds the first position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
+ * [toIndex] (exclusive), which default to 0 and the list size respectively — where [element] could be
+ * inserted while maintaining sorted order.
  * The list is expected to be sorted in a non-descending order according to the specified [comparator],
  * otherwise the result is undefined.
  *
@@ -49,17 +47,9 @@ public fun <T : Comparable<T>> List<T?>.lowerBound(element: T?, fromIndex: Int =
  * according to the [comparator].
  * If all elements are less than [element], returns the end index ([toIndex]).
  * If the list contains multiple elements equal to [element], returns the index of the first such element.
+ * Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * `null` value is considered to be less than any non-null value.
- *
- * @param element the element to search for.
- * @param comparator the comparator used to compare list elements with the element being searched.
- * @param fromIndex the start of the range (inclusive) to search in, 0 by default.
- * @param toIndex the end of the range (exclusive) to search in, size of this list by default.
- *
- * @return the index of the first element that is greater than or equal to [element] according to [comparator],
- *         or [toIndex] if all elements are less than [element].
- *         Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -72,26 +62,21 @@ public fun <T> List<T>.lowerBound(element: T, comparator: Comparator<in T>, from
 }
 
 /**
- * Finds the first position in this sorted list or its range where an element could be inserted while maintaining sorted order,
- * using the binary search algorithm with a custom [comparison] function.
+ * Finds the first position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
+ * [toIndex] (exclusive), which default to 0 and the list size respectively — where an element could be
+ * inserted while maintaining sorted order, using the binary search algorithm with a custom [comparison] function.
  *
- * The list is expected to be sorted so that the signs of the [comparison] function's return values ascend on the list elements,
- * i.e., negative values come before zero and zeroes come before positive values.
+ * [comparison] should return a negative value for elements before the insertion point, zero for elements
+ * equal to the target, and a positive value for elements after it. The list is expected to be sorted so that
+ * the signs of the [comparison] function's return values ascend on the list elements, i.e., negative values
+ * come before zero and zeroes come before positive values.
  * Otherwise, the result is undefined.
  *
  * This function implements the lower bound algorithm: it returns the index of the first element for which [comparison] returns
  * a non-negative value (zero or positive).
  * If [comparison] returns negative for all elements, returns the end index ([toIndex]).
  * If the list contains multiple elements for which [comparison] returns zero, returns the index of the first such element.
- *
- * @param fromIndex the start of the range (inclusive) to search in, 0 by default.
- * @param toIndex the end of the range (exclusive) to search in, size of this list by default.
- * @param comparison function that returns negative values for elements before the insertion point,
- *                   zero for elements equal to the target, and positive values for elements after the target.
- *
- * @return the index of the first element for which [comparison] returns a non-negative value,
- *         or [toIndex] if [comparison] returns negative for all elements.
- *         Unlike [binarySearch], this always returns a non-negative insertion point.
+ * Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -104,25 +89,19 @@ public fun <T> List<T>.lowerBound(fromIndex: Int = 0, toIndex: Int = size, compa
 }
 
 /**
- * Finds the first position in this sorted list or its range where an element having the key equal to the provided [key] value
- * could be inserted while maintaining sorted order, using the binary search algorithm.
+ * Finds the first position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
+ * [toIndex] (exclusive), which default to 0 and the list size respectively — where an element whose key
+ * equals the provided [key] could be inserted while maintaining sorted order, using the binary search
+ * algorithm. The key of each element is obtained via [selector].
  * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of keys of its elements,
  * otherwise the result is undefined.
  *
  * This function implements the lower bound algorithm: it returns the index of the first element whose key is NOT less than [key].
  * If all element keys are less than [key], returns the end index ([toIndex]).
  * If the list contains multiple elements with the specified [key], returns the index of the first such element.
+ * Unlike [binarySearchBy], this always returns a non-negative insertion point.
  *
  * `null` value is considered to be less than any non-null value.
- *
- * @param key the key to search for.
- * @param fromIndex the start of the range (inclusive) to search in, 0 by default.
- * @param toIndex the end of the range (exclusive) to search in, size of this list by default.
- * @param selector the function to extract the key from a list element.
- *
- * @return the index of the first element whose key is greater than or equal to [key],
- *         or [toIndex] if all element keys are less than [key].
- *         Unlike [binarySearchBy], this always returns a non-negative insertion point.
  *
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -137,23 +116,18 @@ public inline fun <T, K : Comparable<K>> List<T>.lowerBoundBy(
 ): Int = lowerBound(fromIndex, toIndex) { compareValues(selector(it), key) }
 
 /**
- * Finds the last position in this sorted list or its range where [element] could be inserted while maintaining sorted order.
+ * Finds the last position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
+ * [toIndex] (exclusive), which default to 0 and the list size respectively — where [element] could be
+ * inserted while maintaining sorted order.
  * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of its elements,
  * otherwise the result is undefined.
  *
  * This function implements the upper bound algorithm: it returns the index of the first element that is GREATER than [element].
  * If all elements are less than or equal to [element], returns the end index ([toIndex]).
  * If the list contains multiple elements equal to [element], returns the index immediately after the last such element.
+ * Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * `null` value is considered to be less than any non-null value.
- *
- * @param element the element to search for.
- * @param fromIndex the start of the range (inclusive) to search in, 0 by default.
- * @param toIndex the end of the range (exclusive) to search in, size of this list by default.
- *
- * @return the index of the first element that is strictly greater than [element],
- *         or [toIndex] if all elements are less than or equal to [element].
- *         Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -169,7 +143,9 @@ public fun <T : Comparable<T>> List<T?>.upperBound(element: T?, fromIndex: Int =
 }
 
 /**
- * Finds the last position in this sorted list or its range where [element] could be inserted while maintaining sorted order.
+ * Finds the last position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
+ * [toIndex] (exclusive), which default to 0 and the list size respectively — where [element] could be
+ * inserted while maintaining sorted order.
  * The list is expected to be sorted in a non-descending order according to the specified [comparator],
  * otherwise the result is undefined.
  *
@@ -177,17 +153,9 @@ public fun <T : Comparable<T>> List<T?>.upperBound(element: T?, fromIndex: Int =
  * according to the [comparator].
  * If all elements are less than or equal to [element], returns the end index ([toIndex]).
  * If the list contains multiple elements equal to [element], returns the index immediately after the last such element.
+ * Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * `null` value is considered to be less than any non-null value.
- *
- * @param element the element to search for.
- * @param comparator the comparator used to compare list elements with the element being searched.
- * @param fromIndex the start of the range (inclusive) to search in, 0 by default.
- * @param toIndex the end of the range (exclusive) to search in, size of this list by default.
- *
- * @return the index of the first element that is strictly greater than [element] according to [comparator],
- *         or [toIndex] if all elements are less than or equal to [element].
- *         Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -200,26 +168,21 @@ public fun <T> List<T>.upperBound(element: T, comparator: Comparator<in T>, from
 }
 
 /**
- * Finds the last position in this sorted list or its range where an element could be inserted while maintaining sorted order,
- * using the binary search algorithm with a custom [comparison] function.
+ * Finds the last position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
+ * [toIndex] (exclusive), which default to 0 and the list size respectively — where an element could be
+ * inserted while maintaining sorted order, using the binary search algorithm with a custom [comparison] function.
  *
- * The list is expected to be sorted so that the signs of the [comparison] function's return values ascend on the list elements,
- * i.e., negative values come before zero and zeroes come before positive values.
+ * [comparison] should return a negative value for elements before the target, zero for elements equal to
+ * the target, and a positive value for elements after it. The list is expected to be sorted so that the
+ * signs of the [comparison] function's return values ascend on the list elements, i.e., negative values
+ * come before zero and zeroes come before positive values.
  * Otherwise, the result is undefined.
  *
  * This function implements the upper bound algorithm: it returns the index of the first element for which [comparison] returns
  * a positive value.
  * If [comparison] returns non-positive (negative or zero) for all elements, returns the end index ([toIndex]).
  * If the list contains multiple elements for which [comparison] returns zero, returns the index immediately after the last such element.
- *
- * @param fromIndex the start of the range (inclusive) to search in, 0 by default.
- * @param toIndex the end of the range (exclusive) to search in, size of this list by default.
- * @param comparison function that returns negative values for elements before the target,
- *                   zero for elements equal to the target, and positive values for elements after the target.
- *
- * @return the index of the first element for which [comparison] returns a positive value,
- *         or [toIndex] if [comparison] returns non-positive for all elements.
- *         Unlike [binarySearch], this always returns a non-negative insertion point.
+ * Unlike [binarySearch], this always returns a non-negative insertion point.
  *
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -232,25 +195,19 @@ public fun <T> List<T>.upperBound(fromIndex: Int = 0, toIndex: Int = size, compa
 }
 
 /**
- * Finds the last position in this sorted list or its range where an element having the key equal to the provided [key] value
- * could be inserted while maintaining sorted order, using the binary search algorithm.
+ * Finds the last position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
+ * [toIndex] (exclusive), which default to 0 and the list size respectively — where an element whose key
+ * equals the provided [key] could be inserted while maintaining sorted order, using the binary search
+ * algorithm. The key of each element is obtained via [selector].
  * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of keys of its elements,
  * otherwise the result is undefined.
  *
  * This function implements the upper bound algorithm: it returns the index of the first element whose key is GREATER than [key].
  * If all element keys are less than or equal to [key], returns the end index ([toIndex]).
  * If the list contains multiple elements with the specified [key], returns the index immediately after the last such element.
+ * Unlike [binarySearchBy], this always returns a non-negative insertion point.
  *
  * `null` value is considered to be less than any non-null value.
- *
- * @param key the key to search for.
- * @param fromIndex the start of the range (inclusive) to search in, 0 by default.
- * @param toIndex the end of the range (exclusive) to search in, size of this list by default.
- * @param selector the function to extract the key from a list element.
- *
- * @return the index of the first element whose key is strictly greater than [key],
- *         or [toIndex] if all element keys are less than or equal to [key].
- *         Unlike [binarySearchBy], this always returns a non-negative insertion point.
  *
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].

--- a/src/commonMain/kotlin/kodvent/collections/MapExtensions.kt
+++ b/src/commonMain/kotlin/kodvent/collections/MapExtensions.kt
@@ -8,12 +8,10 @@
 package kodvent.collections
 
 /**
- * Increments the count for the specified key by 1.
+ * Increments the count for the specified [key] by 1.
  *
  * If the key does not exist in the map, it will be added with a value of 1.
  * If the key already exists, its value will be increased by 1.
- *
- * @param key The key whose count should be incremented
  *
  * @sample samples.IncrementAndDecrementSamples.incrementBasicUsage
  * @sample samples.IncrementAndDecrementSamples.incrementCountingWords
@@ -23,15 +21,12 @@ public fun <T> MutableMap<T, Int>.increment(key: T) {
 }
 
 /**
- * Decrements the count for the specified key by 1.
+ * Decrements the count for the specified [key] by 1, returning `true` if the [key] existed (and was
+ * decremented or removed) or `false` if it was not found.
  *
  * If the key's count is greater than 1, it will be decreased by 1.
  * If the key's count is exactly 1, the key will be removed from the map.
  * If the key does not exist in the map, no changes are made.
- *
- * @param key The key whose count should be decremented
- *
- * @return `true` if the key existed and was decremented or removed, `false` if the key was not found
  *
  * @sample samples.IncrementAndDecrementSamples.decrementBasicUsage
  * @sample samples.IncrementAndDecrementSamples.decrementInventoryManagement

--- a/src/commonMain/kotlin/kodvent/datastructures/DisjointSetUnion.kt
+++ b/src/commonMain/kotlin/kodvent/datastructures/DisjointSetUnion.kt
@@ -22,8 +22,8 @@ package kodvent.datastructures
  * These optimizations provide near-constant
  * [amortized](https://en.wikipedia.org/wiki/Amortized_analysis) time complexity for both operations.
  *
- * @param size The number of elements in the disjoint set. Elements are represented by integers
- *             in the range [0, [size]). Initially, each element is in its own set.
+ * Elements are represented by integers in the range [0, [size]); initially each element is in its
+ * own singleton set.
  *
  * @constructor Creates a DisjointSetUnion with [size] elements, where each element is initially
  *              in its own singleton set.
@@ -48,10 +48,6 @@ public class DisjointSetUnion(size: Int) {
      * Time complexity: O(α(n)) amortized, where α is the inverse
      * [Ackermann function](https://en.wikipedia.org/wiki/Ackermann_function) (nearly constant).
      *
-     * @param x The element whose set representative to find. Must be in range [0, [size]).
-     *
-     * @return The representative element of the set containing [x].
-     *
      * @throws IndexOutOfBoundsException if [x] is not in the valid range [0, [size]).
      *
      * @sample samples.DisjointSetUnionSamples.findingRepresentatives
@@ -67,7 +63,8 @@ public class DisjointSetUnion(size: Int) {
     }
 
     /**
-     * Merges the sets containing elements [x] and [y].
+     * Merges the sets containing elements [x] and [y], returning `true` if a merge occurred (they were
+     * previously disjoint) or `false` if [x] and [y] were already in the same set.
      *
      * This operation uses union by rank: the tree with a smaller rank is attached under the root
      * of the tree with a larger rank. If ranks are equal, one tree is attached to the other and
@@ -75,12 +72,6 @@ public class DisjointSetUnion(size: Int) {
      *
      * Time complexity: O(α(n)) amortized, where α is the inverse
      * [Ackermann function](https://en.wikipedia.org/wiki/Ackermann_function) (nearly constant).
-     *
-     * @param x The first element. Must be in range [0, [size]).
-     * @param y The second element. Must be in range [0, [size]).
-     *
-     * @return `true` if the sets were merged (they were previously disjoint), `false` if [x] and [y]
-     *         were already in the same set.
      *
      * @throws IndexOutOfBoundsException if [x] or [y] is not in the valid range [0, [size]).
      *
@@ -113,15 +104,10 @@ public class DisjointSetUnion(size: Int) {
     }
 
     /**
-     * Checks if elements [x] and [y] are in the same set.
+     * Checks whether elements [x] and [y] are in the same set; returns `true` if they are, `false` otherwise.
      *
      * Time complexity: O(α(n)) amortized, where α is the inverse
      * [Ackermann function](https://en.wikipedia.org/wiki/Ackermann_function) (nearly constant).
-     *
-     * @param x The first element. Must be in range [0, [size]).
-     * @param y The second element. Must be in range [0, [size]).
-     *
-     * @return `true` if [x] and [y] are in the same set, `false` otherwise.
      *
      * @throws IndexOutOfBoundsException if [x] or [y] is not in the valid range [0, [size]).
      *
@@ -148,8 +134,6 @@ public class DisjointSetUnion(size: Int) {
      *
      * Time complexity: O(n), where n is the [size] of the disjoint set, as it may need
      *                  to find all elements in the set and reconnect them.
-     *
-     * @param x The element to reset. Must be in range [0, [size]).
      *
      * @throws IndexOutOfBoundsException if [x] is not in the valid range [0, [size]).
      *

--- a/src/commonMain/kotlin/kodvent/datastructures/SegmentTree.kt
+++ b/src/commonMain/kotlin/kodvent/datastructures/SegmentTree.kt
@@ -23,10 +23,9 @@ package kodvent.datastructures
  * ## Space Complexity
  * - O(4n) internal storage (O(n) in Big-O notation) where n is the size of the [source] list
  *
- * @param T the type of elements in the segment tree
- * @param source the initial list of elements to build the segment tree from
- * @param operation an associative binary operation (e.g., sum, min, max, gcd) to combine elements.
- *        Must be associative: `operation(a, operation(b, c)) == operation(operation(a, b), c)`
+ * The tree is built from a [source] list of elements of type [T] and combines them with
+ * [operation], an associative binary operation (e.g. sum, min, max, gcd) satisfying
+ * `operation(a, operation(b, c)) == operation(operation(a, b), c)`.
  *
  * @sample samples.SegmentTreeSamples.basicRangeSumQuery
  * @sample samples.SegmentTreeSamples.rangeMinimumQuery
@@ -51,11 +50,6 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
      *
      * This operator function allows using bracket notation for range queries.
      *
-     * @param start the starting index of the range (inclusive); must be non-negative
-     * @param end the ending index of the range (inclusive); must be less than the tree size
-     *
-     * @return the result of applying the operation to all elements in the range [[start], [end]]
-     *
      * @throws IllegalArgumentException if the tree is empty or [start] > [end]
      * @throws IndexOutOfBoundsException if [start] is negative or [end] is out of bounds
      *
@@ -73,14 +67,10 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
     }
 
     /**
-     * Queries the value at a single [index] position.
+     * Queries the value at a single [index] position, which must be in the range [0, [size]).
      *
      * This is a convenience operator function that allows using bracket notation with a single index
      * to query individual elements. It is equivalent to calling `get(index, index)`.
-     *
-     * @param index the index of the element to query; must be in range [0, [size])
-     *
-     * @return the value at the specified [index]
      *
      * @throws IllegalArgumentException if the tree is empty
      * @throws IndexOutOfBoundsException if [index] is out of bounds
@@ -91,16 +81,10 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
 
     /**
      * Queries the result of applying the operation over the range [[start], [end]] (inclusive),
-     * returning null if the indices are invalid.
+     * returning null if the indices are invalid — that is, if [start] < 0, [end] >= [size], or [start] > [end].
      *
      * This is a safe version of [get] that returns null instead of throwing an exception
      * when the indices are out of bounds or invalid.
-     *
-     * @param start the starting index of the range (inclusive)
-     * @param end the ending index of the range (inclusive)
-     *
-     * @return the result of applying the operation to all elements in the range, or null if
-     *         [start] < 0, [end] >= [size], or [start] > [end]
      *
      * @sample samples.SegmentTreeSamples.safeQueryMethods
      */
@@ -111,24 +95,18 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
 
     /**
      * Queries the result of applying the operation over the range [[start], [end]] (inclusive),
-     * returning a [defaultValue] if the indices are invalid.
+     * returning [defaultValue] if the indices are invalid — that is, if [start] < 0, [end] >= [size],
+     * or [start] > [end].
      *
      * This is a safe version of [get] that returns a [defaultValue] instead of throwing an exception
      * when the indices are out of bounds or invalid.
-     *
-     * @param start the starting index of the range (inclusive)
-     * @param end the ending index of the range (inclusive)
-     * @param defaultValue the value to return if the indices are invalid
-     *
-     * @return the result of applying the operation to all elements in the range, or [defaultValue] if
-     *         [start] < 0, [end] >= [size], or [start] > [end]
      *
      * @sample samples.SegmentTreeSamples.safeQueryMethods
      */
     public fun getOrDefault(start: Int, end: Int, defaultValue: T): T = getOrNull(start, end) ?: defaultValue
 
     /**
-     * Updates the value at the specified [index] to a [value].
+     * Updates the value at the specified [index] (which must be in the range [0, [size])) to [value].
      *
      * This operator function allows using assignment syntax to update elements.
      * The operation updates a single element in the segment tree and propagates
@@ -136,9 +114,6 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
      *
      * Since both [get] and [set] operators are defined, compound assignment operators
      * (`+=`, `-=`, `*=`, `/=`, `%=`) work automatically by combining get and set operations.
-     *
-     * @param index the index of the element to update; must be in range [0, [size])
-     * @param value the new value to set at the specified index
      *
      * @throws IllegalArgumentException if the tree is empty
      * @throws IndexOutOfBoundsException if [index] is out of bounds

--- a/src/commonMain/kotlin/kodvent/math/Functions.kt
+++ b/src/commonMain/kotlin/kodvent/math/Functions.kt
@@ -8,14 +8,9 @@
 package kodvent.math
 
 /**
- * Computes the greatest common divisor (GCD) of two integers using the Euclidean algorithm.
+ * Computes the greatest common divisor (GCD) of two integers, [a] and [b], using the Euclidean algorithm.
  *
  * The GCD is the largest positive integer that divides both numbers without a remainder.
- *
- * @param a the first integer
- * @param b the second integer
- *
- * @return the greatest common divisor of [a] and [b]
  *
  * @see lcm
  *
@@ -26,16 +21,11 @@ package kodvent.math
 public tailrec fun gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
 
 /**
- * Computes the least common multiple (LCM) of two integers.
+ * Computes the least common multiple (LCM) of two integers, [a] and [b].
  *
  * The LCM is the smallest positive integer that is divisible by both numbers.
  * This function uses the relationship: `lcm(a, b) = (a * b) / gcd(a, b)`,
  * but calculates it as `(a / gcd(a, b)) * b` to reduce the risk of integer overflow.
- *
- * @param a the first integer
- * @param b the second integer
- *
- * @return the least common multiple of [a] and [b]
  *
  * @see gcd
  *
@@ -55,7 +45,7 @@ public tailrec fun gcd(a: Long, b: Long): Long = if (b == 0L) a else gcd(b, a % 
 public fun lcm(a: Long, b: Long): Long = if (a == 0L || b == 0L) 0L else a / gcd(a, b) * b
 
 /**
- * Raises this Long to the given power using binary exponentiation.
+ * Raises this Long to the given [power] (which must be non-negative) using binary exponentiation.
  *
  * This function uses the fast binary exponentiation algorithm
  * (also known as [exponentiation by squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring)),
@@ -63,10 +53,6 @@ public fun lcm(a: Long, b: Long): Long = if (a == 0L || b == 0L) 0L else a / gcd
  *
  * **Warning**: This function does not check for overflow. For large bases or exponents,
  * the result may overflow and wrap around.
- *
- * @param power the exponent (must be non-negative)
- *
- * @return this number raised to the power of [power]
  *
  * @see pow overload with modulo parameter for modular exponentiation
  *
@@ -79,16 +65,12 @@ public infix fun Long.pow(power: Long): Long {
 }
 
 /**
- * Raises this Long to the given power modulo a specified value using binary exponentiation.
+ * Raises this Long to the given [power] (which must be non-negative), modulo [modulo] (which must be
+ * positive), using binary exponentiation; the result is in the range `[0, modulo)`.
  *
  * This function uses the fast binary exponentiation algorithm with modular arithmetic,
  * computing the result in O(log n) time, where n is the exponent. The modulo operation
  * is applied at each step to prevent overflow.
- *
- * @param power the exponent (must be non-negative)
- * @param modulo the modulus value (must be positive)
- *
- * @return this number raised to the power of [power], modulo [modulo]; the result is in the range [0, modulo)
  *
  * @see pow overload without a modulo parameter for regular exponentiation
  *
@@ -119,8 +101,6 @@ private inline fun binaryExponentiation(base: Long, power: Long, multiply: (Long
 /**
  * Returns the square of [this] Int value.
  *
- * @return the square of [this] value
- *
  * @sample samples.SqrSamples.sqrBasicUsage
  * @sample samples.SqrSamples.sqrDistanceCalculation
  * @sample samples.SqrSamples.sqrAreaCalculation
@@ -130,8 +110,6 @@ public fun Int.sqr(): Int = this * this
 /**
  * Returns the square of [this] Long value.
  *
- * @return the square of [this] value
- *
  * @sample samples.SqrSamples.sqrBasicUsage
  * @sample samples.SqrSamples.sqrDistanceCalculation
  * @sample samples.SqrSamples.sqrAreaCalculation
@@ -140,8 +118,6 @@ public fun Long.sqr(): Long = this * this
 
 /**
  * Returns the square of [this] Double value.
- *
- * @return the square of [this] value
  *
  * @sample samples.SqrSamples.sqrBasicUsage
  * @sample samples.SqrSamples.sqrDistanceCalculation

--- a/src/commonMain/kotlin/kodvent/strings/PrefixFunction.kt
+++ b/src/commonMain/kotlin/kodvent/strings/PrefixFunction.kt
@@ -8,7 +8,8 @@
 package kodvent.strings
 
 /**
- * Computes the prefix function for this character sequence.
+ * Computes the prefix function for this character sequence, returning an array whose i-th element is
+ * the length of the longest proper prefix of `this[0..i]` that is also a suffix of `this[0..i]`.
  *
  * The prefix function π_i is defined as the length of the longest proper prefix
  * of the substring `s[0..i]` that is also a suffix of this substring.
@@ -19,9 +20,6 @@ package kodvent.strings
  * - Time: O(n) where n is the length of the character sequence
  * - Space: O(n) for the result array
  *
- * @return an array where the i-th element contains the length of the longest proper prefix
- *         of `this[0..i]` that is also a suffix of `this[0..i]`
- *
  * @sample samples.PrefixFunctionAndKMPSamples.prefixFunctionBasicUsage
  * @sample samples.PrefixFunctionAndKMPSamples.prefixFunctionUnderstandingTheResult
  *
@@ -30,7 +28,9 @@ package kodvent.strings
 public fun CharSequence.prefixFunction(): IntArray = prefixFunction(length, ::get)
 
 /**
- * Computes the prefix function for a generic sequence.
+ * Computes the prefix function for a generic sequence of [length] elements of type [T], where [at]
+ * returns the element at a given index. Returns an array whose i-th element is the length of the
+ * longest proper prefix that is also a suffix for the subsequence `[0..i]`.
  *
  * This is a generalized version of the prefix function that works with any type of sequence
  * where elements can be accessed by index and compared for equality. The prefix function π_i
@@ -39,13 +39,6 @@ public fun CharSequence.prefixFunction(): IntArray = prefixFunction(length, ::ge
  * ## Complexity
  * - Time: O(n) where n is the length parameter
  * - Space: O(n) for the result array
- *
- * @param T the type of elements in the sequence
- * @param length the length of the sequence
- * @param at a function that returns the element at a given index
- *
- * @return an array where the i-th element contains the length of the longest proper prefix
- *         that is also a suffix for the subsequence `[0..i]`
  *
  * @sample samples.PrefixFunctionAndKMPSamples.genericPrefixFunctionWithIntegers
  * @sample samples.PrefixFunctionAndKMPSamples.genericPrefixFunctionWithCustomObjects
@@ -68,17 +61,12 @@ public inline fun <T> prefixFunction(length: Int, at: (Int) -> T): IntArray {
  * This function uses the
  * [Knuth-Morris-Pratt (KMP) algorithm](https://cp-algorithms.com/string/prefix-function.html)
  * to efficiently find all occurrences of the needle string within the text.
- * It concatenates the needle, a delimiter, and the text, then uses the prefix function to identify matches.
+ * It concatenates the needle, the [delimiter] character, and the text, then uses the prefix function to
+ * identify matches. The [delimiter] (default `'#'`) must not appear in either the needle or the text.
  *
  * ## Complexity
  * - Time: O(n + m) where n is the length of this sequence and m is the length of the needle
  * - Space: O(n + m) for the concatenated string and prefix array
- *
- * @param needle the substring to search for
- * @param delimiter a character used to separate the needle from the text in the internal representation.
- *                  Must not appear in either the needle or the text. Defaults to '#'.
- *
- * @return a list of all starting indices where the needle occurs in this character sequence
  *
  * @throws IllegalArgumentException if the delimiter appears in the needle or in this text
  *


### PR DESCRIPTION
The Kotlin coding convention recommends against `@param`/`@return` tags, preferring parameter and return descriptions inline in the prose with `[name]` links. This change applies that across the public KDoc in `commonMain`: each tag's content moves into the description, keeping all parameter constraints, defaults, and return behavior. `@throws`, `@see`, `@sample`, and `@constructor` are untouched, as are the already-compliant `Long` overloads of `gcd`/`lcm` and the `count` property.

Docs only, no API or behavior change. Dokka still generates cleanly, so every `[name]` link resolves (it runs with `failOnWarning`).
