### PR TITLE
Condense KDoc across the library

### DIFF
--- a/src/commonMain/kotlin/kodvent/boundsearch/BoundSearch.kt
+++ b/src/commonMain/kotlin/kodvent/boundsearch/BoundSearch.kt
@@ -8,12 +8,8 @@
 package kodvent.boundsearch
 
 /**
- * Finds the partition point in the range `[[fromIndex], [toIndex])` where a predicate transitions from `true` to `false`.
- *
- * This function uses binary search to efficiently locate the first index in the range where the [predicate]
- * returns `false`, or [toIndex] if [predicate] is `true` for all indices. The predicate must be monotonic:
- * if it returns `false` for some index, it must return `false` for all later indices in the range.
- * [fromIndex] is the inclusive start of the range and [toIndex] the exclusive end.
+ * Binary-searches the range `[[fromIndex], [toIndex])` for the partition point: the first index where the
+ * monotonic [predicate] turns from `true` to `false`, or [toIndex] if it is `true` throughout.
  *
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
  *
@@ -44,12 +40,8 @@ public inline fun partitionPoint(fromIndex: Int, toIndex: Int, predicate: (Int) 
 }
 
 /**
- * Finds the partition point in the range `[[fromIndex], [toIndex])` where a predicate transitions from `true` to `false`.
- *
- * This function uses binary search to efficiently locate the first index in the range where the [predicate]
- * returns `false`, or [toIndex] if [predicate] is `true` for all indices. The predicate must be monotonic:
- * if it returns `false` for some index, it must return `false` for all later indices in the range.
- * [fromIndex] is the inclusive start of the range and [toIndex] the exclusive end.
+ * Binary-searches the range `[[fromIndex], [toIndex])` for the partition point: the first index where the
+ * monotonic [predicate] turns from `true` to `false`, or [toIndex] if it is `true` throughout.
  *
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
  *
@@ -72,11 +64,8 @@ public inline fun partitionPoint(fromIndex: Long, toIndex: Long, predicate: (Lon
 }
 
 /**
- * Finds the argument that maximizes [f] on the interval [[left], [right]]
- * using ternary search, with precision up to `1e-9`.
- *
- * The function [f] must be **unimodal** on the given interval,
- * i.e., strictly increasing then strictly decreasing.
+ * Returns the argument in [[left], [right]] that maximizes the unimodal function [f] (strictly increasing
+ * then strictly decreasing), found by ternary search to within `1e-9`.
  *
  * @throws IllegalArgumentException if [left] > [right].
  *

--- a/src/commonMain/kotlin/kodvent/collections/Collections.kt
+++ b/src/commonMain/kotlin/kodvent/collections/Collections.kt
@@ -10,21 +10,13 @@ package kodvent.collections
 import kodvent.boundsearch.partitionPoint
 
 /**
- * Finds the first position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
- * [toIndex] (exclusive), which default to 0 and the list size respectively — where [element] could be
- * inserted while maintaining sorted order.
- * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of its elements,
- * otherwise the result is undefined.
+ * Returns the lower bound of [element] in this naturally-sorted list: the index of the first element
+ * not less than [element], or [toIndex] if all are smaller. Searches [[fromIndex], [toIndex]) (the whole
+ * list by default); always a non-negative insertion point. `null` sorts before any value, and the result
+ * is undefined if the list isn't sorted.
  *
- * This function implements the lower bound algorithm: it returns the index of the first element that is NOT less than [element].
- * If all elements are less than [element], returns the end index ([toIndex]).
- * If the list contains multiple elements equal to [element], returns the index of the first such element.
- * Unlike [binarySearch], this always returns a non-negative insertion point.
- *
- * `null` value is considered to be less than any non-null value.
- *
- * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
- * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * @throws IndexOutOfBoundsException if [fromIndex] is negative or [toIndex] exceeds the size.
+ * @throws IllegalArgumentException if [fromIndex] exceeds [toIndex].
  *
  * @sample samples.BoundSearchSamples.lowerBoundWithDuplicates
  * @sample samples.BoundSearchSamples.countOccurrencesUsingBounds
@@ -37,22 +29,13 @@ public fun <T : Comparable<T>> List<T?>.lowerBound(element: T?, fromIndex: Int =
 }
 
 /**
- * Finds the first position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
- * [toIndex] (exclusive), which default to 0 and the list size respectively — where [element] could be
- * inserted while maintaining sorted order.
- * The list is expected to be sorted in a non-descending order according to the specified [comparator],
- * otherwise the result is undefined.
+ * Returns the lower bound of [element] in this list sorted by [comparator]: the index of the first
+ * element not less than [element], or [toIndex] if all are smaller. Searches [[fromIndex], [toIndex])
+ * (the whole list by default); always a non-negative insertion point. `null` sorts before any value, and
+ * the result is undefined if the list isn't sorted.
  *
- * This function implements the lower bound algorithm: it returns the index of the first element that is NOT less than [element]
- * according to the [comparator].
- * If all elements are less than [element], returns the end index ([toIndex]).
- * If the list contains multiple elements equal to [element], returns the index of the first such element.
- * Unlike [binarySearch], this always returns a non-negative insertion point.
- *
- * `null` value is considered to be less than any non-null value.
- *
- * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
- * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * @throws IndexOutOfBoundsException if [fromIndex] is negative or [toIndex] exceeds the size.
+ * @throws IllegalArgumentException if [fromIndex] exceeds [toIndex].
  *
  * @sample samples.BoundSearchSamples.lowerBoundWithComparator
  */
@@ -62,24 +45,13 @@ public fun <T> List<T>.lowerBound(element: T, comparator: Comparator<in T>, from
 }
 
 /**
- * Finds the first position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
- * [toIndex] (exclusive), which default to 0 and the list size respectively — where an element could be
- * inserted while maintaining sorted order, using the binary search algorithm with a custom [comparison] function.
+ * Returns the lower bound using a [comparison] function (negative before the target, zero at it, positive
+ * after): the index of the first element for which [comparison] is non-negative, or [toIndex] if it is
+ * negative for all. Searches [[fromIndex], [toIndex]) (the whole list by default); always a non-negative
+ * insertion point. The result is undefined unless [comparison]'s sign is non-decreasing over the list.
  *
- * [comparison] should return a negative value for elements before the insertion point, zero for elements
- * equal to the target, and a positive value for elements after it. The list is expected to be sorted so that
- * the signs of the [comparison] function's return values ascend on the list elements, i.e., negative values
- * come before zero and zeroes come before positive values.
- * Otherwise, the result is undefined.
- *
- * This function implements the lower bound algorithm: it returns the index of the first element for which [comparison] returns
- * a non-negative value (zero or positive).
- * If [comparison] returns negative for all elements, returns the end index ([toIndex]).
- * If the list contains multiple elements for which [comparison] returns zero, returns the index of the first such element.
- * Unlike [binarySearch], this always returns a non-negative insertion point.
- *
- * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
- * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * @throws IndexOutOfBoundsException if [fromIndex] is negative or [toIndex] exceeds the size.
+ * @throws IllegalArgumentException if [fromIndex] exceeds [toIndex].
  *
  * @sample samples.BoundSearchSamples.lowerBoundWithComparisonFunction
  */
@@ -89,22 +61,13 @@ public fun <T> List<T>.lowerBound(fromIndex: Int = 0, toIndex: Int = size, compa
 }
 
 /**
- * Finds the first position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
- * [toIndex] (exclusive), which default to 0 and the list size respectively — where an element whose key
- * equals the provided [key] could be inserted while maintaining sorted order, using the binary search
- * algorithm. The key of each element is obtained via [selector].
- * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of keys of its elements,
- * otherwise the result is undefined.
+ * Returns the lower bound of [key] in this list, sorted by the keys from [selector]: the index of the
+ * first element whose key is not less than [key], or [toIndex] if all keys are smaller. Searches
+ * [[fromIndex], [toIndex]) (the whole list by default); always a non-negative insertion point. `null`
+ * sorts before any value, and the result is undefined if the list isn't sorted by key.
  *
- * This function implements the lower bound algorithm: it returns the index of the first element whose key is NOT less than [key].
- * If all element keys are less than [key], returns the end index ([toIndex]).
- * If the list contains multiple elements with the specified [key], returns the index of the first such element.
- * Unlike [binarySearchBy], this always returns a non-negative insertion point.
- *
- * `null` value is considered to be less than any non-null value.
- *
- * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
- * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * @throws IndexOutOfBoundsException if [fromIndex] is negative or [toIndex] exceeds the size.
+ * @throws IllegalArgumentException if [fromIndex] exceeds [toIndex].
  *
  * @sample samples.BoundSearchSamples.lowerBoundByWithSelector
  */
@@ -116,21 +79,13 @@ public inline fun <T, K : Comparable<K>> List<T>.lowerBoundBy(
 ): Int = lowerBound(fromIndex, toIndex) { compareValues(selector(it), key) }
 
 /**
- * Finds the last position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
- * [toIndex] (exclusive), which default to 0 and the list size respectively — where [element] could be
- * inserted while maintaining sorted order.
- * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of its elements,
- * otherwise the result is undefined.
+ * Returns the upper bound of [element] in this naturally-sorted list: the index of the first element
+ * greater than [element], or [toIndex] if none is. Searches [[fromIndex], [toIndex]) (the whole list by
+ * default); always a non-negative insertion point. `null` sorts before any value, and the result is
+ * undefined if the list isn't sorted.
  *
- * This function implements the upper bound algorithm: it returns the index of the first element that is GREATER than [element].
- * If all elements are less than or equal to [element], returns the end index ([toIndex]).
- * If the list contains multiple elements equal to [element], returns the index immediately after the last such element.
- * Unlike [binarySearch], this always returns a non-negative insertion point.
- *
- * `null` value is considered to be less than any non-null value.
- *
- * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
- * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * @throws IndexOutOfBoundsException if [fromIndex] is negative or [toIndex] exceeds the size.
+ * @throws IllegalArgumentException if [fromIndex] exceeds [toIndex].
  *
  * @sample samples.BoundSearchSamples.upperBoundWithDuplicates
  * @sample samples.BoundSearchSamples.countOccurrencesUsingBounds
@@ -143,22 +98,13 @@ public fun <T : Comparable<T>> List<T?>.upperBound(element: T?, fromIndex: Int =
 }
 
 /**
- * Finds the last position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
- * [toIndex] (exclusive), which default to 0 and the list size respectively — where [element] could be
- * inserted while maintaining sorted order.
- * The list is expected to be sorted in a non-descending order according to the specified [comparator],
- * otherwise the result is undefined.
+ * Returns the upper bound of [element] in this list sorted by [comparator]: the index of the first
+ * element greater than [element], or [toIndex] if none is. Searches [[fromIndex], [toIndex]) (the whole
+ * list by default); always a non-negative insertion point. `null` sorts before any value, and the result
+ * is undefined if the list isn't sorted.
  *
- * This function implements the upper bound algorithm: it returns the index of the first element that is GREATER than [element]
- * according to the [comparator].
- * If all elements are less than or equal to [element], returns the end index ([toIndex]).
- * If the list contains multiple elements equal to [element], returns the index immediately after the last such element.
- * Unlike [binarySearch], this always returns a non-negative insertion point.
- *
- * `null` value is considered to be less than any non-null value.
- *
- * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
- * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * @throws IndexOutOfBoundsException if [fromIndex] is negative or [toIndex] exceeds the size.
+ * @throws IllegalArgumentException if [fromIndex] exceeds [toIndex].
  *
  * @sample samples.BoundSearchSamples.upperBoundWithComparator
  */
@@ -168,24 +114,13 @@ public fun <T> List<T>.upperBound(element: T, comparator: Comparator<in T>, from
 }
 
 /**
- * Finds the last position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
- * [toIndex] (exclusive), which default to 0 and the list size respectively — where an element could be
- * inserted while maintaining sorted order, using the binary search algorithm with a custom [comparison] function.
+ * Returns the upper bound using a [comparison] function (negative before the target, zero at it, positive
+ * after): the index of the first element for which [comparison] is positive, or [toIndex] if it is
+ * non-positive for all. Searches [[fromIndex], [toIndex]) (the whole list by default); always a
+ * non-negative insertion point. The result is undefined unless [comparison]'s sign is non-decreasing over the list.
  *
- * [comparison] should return a negative value for elements before the target, zero for elements equal to
- * the target, and a positive value for elements after it. The list is expected to be sorted so that the
- * signs of the [comparison] function's return values ascend on the list elements, i.e., negative values
- * come before zero and zeroes come before positive values.
- * Otherwise, the result is undefined.
- *
- * This function implements the upper bound algorithm: it returns the index of the first element for which [comparison] returns
- * a positive value.
- * If [comparison] returns non-positive (negative or zero) for all elements, returns the end index ([toIndex]).
- * If the list contains multiple elements for which [comparison] returns zero, returns the index immediately after the last such element.
- * Unlike [binarySearch], this always returns a non-negative insertion point.
- *
- * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
- * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * @throws IndexOutOfBoundsException if [fromIndex] is negative or [toIndex] exceeds the size.
+ * @throws IllegalArgumentException if [fromIndex] exceeds [toIndex].
  *
  * @sample samples.BoundSearchSamples.upperBoundWithComparisonFunction
  */
@@ -195,22 +130,13 @@ public fun <T> List<T>.upperBound(fromIndex: Int = 0, toIndex: Int = size, compa
 }
 
 /**
- * Finds the last position in this sorted list — or in the sub-range from [fromIndex] (inclusive) to
- * [toIndex] (exclusive), which default to 0 and the list size respectively — where an element whose key
- * equals the provided [key] could be inserted while maintaining sorted order, using the binary search
- * algorithm. The key of each element is obtained via [selector].
- * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of keys of its elements,
- * otherwise the result is undefined.
+ * Returns the upper bound of [key] in this list, sorted by the keys from [selector]: the index of the
+ * first element whose key is greater than [key], or [toIndex] if none is. Searches [[fromIndex], [toIndex])
+ * (the whole list by default); always a non-negative insertion point. `null` sorts before any value, and
+ * the result is undefined if the list isn't sorted by key.
  *
- * This function implements the upper bound algorithm: it returns the index of the first element whose key is GREATER than [key].
- * If all element keys are less than or equal to [key], returns the end index ([toIndex]).
- * If the list contains multiple elements with the specified [key], returns the index immediately after the last such element.
- * Unlike [binarySearchBy], this always returns a non-negative insertion point.
- *
- * `null` value is considered to be less than any non-null value.
- *
- * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
- * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * @throws IndexOutOfBoundsException if [fromIndex] is negative or [toIndex] exceeds the size.
+ * @throws IllegalArgumentException if [fromIndex] exceeds [toIndex].
  *
  * @sample samples.BoundSearchSamples.upperBoundByWithSelector
  */

--- a/src/commonMain/kotlin/kodvent/collections/MapExtensions.kt
+++ b/src/commonMain/kotlin/kodvent/collections/MapExtensions.kt
@@ -8,10 +8,7 @@
 package kodvent.collections
 
 /**
- * Increments the count for the specified [key] by 1.
- *
- * If the key does not exist in the map, it will be added with a value of 1.
- * If the key already exists, its value will be increased by 1.
+ * Increments the count for [key] by 1, treating a missing [key] as 0.
  *
  * @sample samples.IncrementAndDecrementSamples.incrementBasicUsage
  * @sample samples.IncrementAndDecrementSamples.incrementCountingWords
@@ -21,12 +18,8 @@ public fun <T> MutableMap<T, Int>.increment(key: T) {
 }
 
 /**
- * Decrements the count for the specified [key] by 1, returning `true` if the [key] existed (and was
- * decremented or removed) or `false` if it was not found.
- *
- * If the key's count is greater than 1, it will be decreased by 1.
- * If the key's count is exactly 1, the key will be removed from the map.
- * If the key does not exist in the map, no changes are made.
+ * Decrements the count for [key] by 1, removing it when the count reaches 0. Returns `true` if [key] was
+ * present, `false` otherwise.
  *
  * @sample samples.IncrementAndDecrementSamples.decrementBasicUsage
  * @sample samples.IncrementAndDecrementSamples.decrementInventoryManagement

--- a/src/commonMain/kotlin/kodvent/datastructures/DisjointSetUnion.kt
+++ b/src/commonMain/kotlin/kodvent/datastructures/DisjointSetUnion.kt
@@ -8,25 +8,15 @@
 package kodvent.datastructures
 
 /**
- * A [Disjoint Set Union](https://en.wikipedia.org/wiki/Disjoint-set_data_structure)
- * (DSU) data structure, also known as Union-Find.
+ * A [Disjoint Set Union](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) (DSU, or Union-Find):
+ * maintains a partition of the integers in `[0, size)` into disjoint sets.
  *
- * This data structure efficiently maintains a partition of a set of elements into disjoint subsets
- * and supports two primary operations: finding which subset an element belongs to (find) and
- * merging two subsets into one (union).
+ * Path compression and union by rank give near-constant
+ * [amortized](https://en.wikipedia.org/wiki/Amortized_analysis) time per operation — O(α(n)), where α is
+ * the inverse [Ackermann function](https://en.wikipedia.org/wiki/Ackermann_function). Initially each
+ * element is in its own singleton set.
  *
- * The implementation uses two key optimizations:
- * - **Path compression** during find operations: makes elements point directly to the root
- * - **Union by rank**: attaches the smaller tree under the root of the larger tree
- *
- * These optimizations provide near-constant
- * [amortized](https://en.wikipedia.org/wiki/Amortized_analysis) time complexity for both operations.
- *
- * Elements are represented by integers in the range [0, [size]); initially each element is in its
- * own singleton set.
- *
- * @constructor Creates a DisjointSetUnion with [size] elements, where each element is initially
- *              in its own singleton set.
+ * @constructor Creates a DSU of [size] singleton elements.
  *
  * @sample samples.DisjointSetUnionSamples.basicUsage
  * @sample samples.DisjointSetUnionSamples.networkConnectivity
@@ -40,15 +30,9 @@ public class DisjointSetUnion(size: Int) {
     private var _count = size
 
     /**
-     * Finds the representative (root) of the set containing element [x].
+     * Returns the representative (root) of the set containing [x]. O(α(n)) amortized.
      *
-     * This operation uses path compression: during the search, it makes every node on the path
-     * point directly to the root, which speeds up future queries.
-     *
-     * Time complexity: O(α(n)) amortized, where α is the inverse
-     * [Ackermann function](https://en.wikipedia.org/wiki/Ackermann_function) (nearly constant).
-     *
-     * @throws IndexOutOfBoundsException if [x] is not in the valid range [0, [size]).
+     * @throws IndexOutOfBoundsException if [x] is not in `[0, size)`.
      *
      * @sample samples.DisjointSetUnionSamples.findingRepresentatives
      */
@@ -63,17 +47,10 @@ public class DisjointSetUnion(size: Int) {
     }
 
     /**
-     * Merges the sets containing elements [x] and [y], returning `true` if a merge occurred (they were
-     * previously disjoint) or `false` if [x] and [y] were already in the same set.
+     * Merges the sets containing [x] and [y]. Returns `true` if they were merged, or `false` if they were
+     * already in the same set. O(α(n)) amortized.
      *
-     * This operation uses union by rank: the tree with a smaller rank is attached under the root
-     * of the tree with a larger rank. If ranks are equal, one tree is attached to the other and
-     * the rank of the new root is increased.
-     *
-     * Time complexity: O(α(n)) amortized, where α is the inverse
-     * [Ackermann function](https://en.wikipedia.org/wiki/Ackermann_function) (nearly constant).
-     *
-     * @throws IndexOutOfBoundsException if [x] or [y] is not in the valid range [0, [size]).
+     * @throws IndexOutOfBoundsException if [x] or [y] is not in `[0, size)`.
      *
      * @sample samples.DisjointSetUnionSamples.basicUsage
      * @sample samples.DisjointSetUnionSamples.detectingCycles
@@ -104,21 +81,16 @@ public class DisjointSetUnion(size: Int) {
     }
 
     /**
-     * Checks whether elements [x] and [y] are in the same set; returns `true` if they are, `false` otherwise.
+     * Returns `true` if [x] and [y] are in the same set. O(α(n)) amortized.
      *
-     * Time complexity: O(α(n)) amortized, where α is the inverse
-     * [Ackermann function](https://en.wikipedia.org/wiki/Ackermann_function) (nearly constant).
-     *
-     * @throws IndexOutOfBoundsException if [x] or [y] is not in the valid range [0, [size]).
+     * @throws IndexOutOfBoundsException if [x] or [y] is not in `[0, size)`.
      *
      * @sample samples.DisjointSetUnionSamples.networkConnectivity
      */
     public fun connected(x: Int, y: Int): Boolean = find(x) == find(y)
 
     /**
-     * The number of disjoint sets.
-     *
-     * Time complexity: O(1).
+     * The number of disjoint sets. O(1).
      *
      * @sample samples.DisjointSetUnionSamples.dynamicConnectivityUpdates
      */
@@ -126,16 +98,10 @@ public class DisjointSetUnion(size: Int) {
         get() = _count
 
     /**
-     * Resets element [x] to be in its own singleton set.
+     * Removes [x] from its current set, putting it in its own singleton; the other members of that set
+     * stay connected. O(n), since it may rebuild the set.
      *
-     * This operation makes [x] the representative of a new set containing only itself,
-     * effectively removing it from any set it was previously part of. Other elements
-     * that were in the same set remain connected.
-     *
-     * Time complexity: O(n), where n is the [size] of the disjoint set, as it may need
-     *                  to find all elements in the set and reconnect them.
-     *
-     * @throws IndexOutOfBoundsException if [x] is not in the valid range [0, [size]).
+     * @throws IndexOutOfBoundsException if [x] is not in `[0, size)`.
      *
      * @sample samples.DisjointSetUnionSamples.isolateUsage
      */

--- a/src/commonMain/kotlin/kodvent/datastructures/SegmentTree.kt
+++ b/src/commonMain/kotlin/kodvent/datastructures/SegmentTree.kt
@@ -8,24 +8,11 @@
 package kodvent.datastructures
 
 /**
- * A [segment tree data structure](https://en.wikipedia.org/wiki/Segment_tree)
- * that supports efficient range queries and point updates.
+ * A [segment tree](https://en.wikipedia.org/wiki/Segment_tree) over a [source] list of elements of
+ * type [T], supporting range queries and point updates via an associative [operation] (e.g. sum, min,
+ * max, gcd): `operation(a, operation(b, c)) == operation(operation(a, b), c)`.
  *
- * A segment tree is a binary tree used for storing intervals or segments. It allows querying
- * which of the stored segments contain a given point and supports efficient range queries
- * using an associative binary operation.
- *
- * ## Time Complexity
- * - Construction: O(n)
- * - Range query: O(log n)
- * - Point update: O(log n)
- *
- * ## Space Complexity
- * - O(4n) internal storage (O(n) in Big-O notation) where n is the size of the [source] list
- *
- * The tree is built from a [source] list of elements of type [T] and combines them with
- * [operation], an associative binary operation (e.g. sum, min, max, gcd) satisfying
- * `operation(a, operation(b, c)) == operation(operation(a, b), c)`.
+ * Construction is O(n); range query and point update are O(log n). Uses O(n) space.
  *
  * @sample samples.SegmentTreeSamples.basicRangeSumQuery
  * @sample samples.SegmentTreeSamples.rangeMinimumQuery
@@ -46,9 +33,7 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
     }
 
     /**
-     * Queries the result of applying the operation over the range [[start], [end]] (inclusive).
-     *
-     * This operator function allows using bracket notation for range queries.
+     * Returns the [operation] applied over the inclusive range [[start], [end]].
      *
      * @throws IllegalArgumentException if the tree is empty or [start] > [end]
      * @throws IndexOutOfBoundsException if [start] is negative or [end] is out of bounds
@@ -67,10 +52,7 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
     }
 
     /**
-     * Queries the value at a single [index] position, which must be in the range [0, [size]).
-     *
-     * This is a convenience operator function that allows using bracket notation with a single index
-     * to query individual elements. It is equivalent to calling `get(index, index)`.
+     * Returns the value at [index], equivalent to `get(index, index)`. [index] must be in `[0, size)`.
      *
      * @throws IllegalArgumentException if the tree is empty
      * @throws IndexOutOfBoundsException if [index] is out of bounds
@@ -80,11 +62,8 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
     public operator fun get(index: Int): T = get(index, index)
 
     /**
-     * Queries the result of applying the operation over the range [[start], [end]] (inclusive),
-     * returning null if the indices are invalid — that is, if [start] < 0, [end] >= [size], or [start] > [end].
-     *
-     * This is a safe version of [get] that returns null instead of throwing an exception
-     * when the indices are out of bounds or invalid.
+     * Like [get] over the inclusive range [[start], [end]], but returns null for out-of-range or inverted
+     * ([start] > [end]) indices instead of throwing.
      *
      * @sample samples.SegmentTreeSamples.safeQueryMethods
      */
@@ -94,26 +73,16 @@ public class SegmentTree<T>(source: List<T>, private val operation: (T, T) -> T)
     }
 
     /**
-     * Queries the result of applying the operation over the range [[start], [end]] (inclusive),
-     * returning [defaultValue] if the indices are invalid — that is, if [start] < 0, [end] >= [size],
-     * or [start] > [end].
-     *
-     * This is a safe version of [get] that returns a [defaultValue] instead of throwing an exception
-     * when the indices are out of bounds or invalid.
+     * Like [get] over the inclusive range [[start], [end]], but returns [defaultValue] for out-of-range or
+     * inverted ([start] > [end]) indices instead of throwing.
      *
      * @sample samples.SegmentTreeSamples.safeQueryMethods
      */
     public fun getOrDefault(start: Int, end: Int, defaultValue: T): T = getOrNull(start, end) ?: defaultValue
 
     /**
-     * Updates the value at the specified [index] (which must be in the range [0, [size])) to [value].
-     *
-     * This operator function allows using assignment syntax to update elements.
-     * The operation updates a single element in the segment tree and propagates
-     * the change up through all affected nodes in O(log n) time.
-     *
-     * Since both [get] and [set] operators are defined, compound assignment operators
-     * (`+=`, `-=`, `*=`, `/=`, `%=`) work automatically by combining get and set operations.
+     * Sets the value at [index] (which must be in `[0, size)`) to [value], in O(log n) time. Since [get]
+     * and [set] are both defined, compound assignments (`+=`, `-=`, `*=`, `/=`, `%=`) work too.
      *
      * @throws IllegalArgumentException if the tree is empty
      * @throws IndexOutOfBoundsException if [index] is out of bounds

--- a/src/commonMain/kotlin/kodvent/math/Functions.kt
+++ b/src/commonMain/kotlin/kodvent/math/Functions.kt
@@ -8,9 +8,7 @@
 package kodvent.math
 
 /**
- * Computes the greatest common divisor (GCD) of two integers, [a] and [b], using the Euclidean algorithm.
- *
- * The GCD is the largest positive integer that divides both numbers without a remainder.
+ * Computes the greatest common divisor of [a] and [b] using the Euclidean algorithm.
  *
  * @see lcm
  *
@@ -21,11 +19,7 @@ package kodvent.math
 public tailrec fun gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
 
 /**
- * Computes the least common multiple (LCM) of two integers, [a] and [b].
- *
- * The LCM is the smallest positive integer that is divisible by both numbers.
- * This function uses the relationship: `lcm(a, b) = (a * b) / gcd(a, b)`,
- * but calculates it as `(a / gcd(a, b)) * b` to reduce the risk of integer overflow.
+ * Computes the least common multiple of [a] and [b], as `(a / gcd(a, b)) * b` to reduce the risk of overflow.
  *
  * @see gcd
  *
@@ -45,14 +39,10 @@ public tailrec fun gcd(a: Long, b: Long): Long = if (b == 0L) a else gcd(b, a % 
 public fun lcm(a: Long, b: Long): Long = if (a == 0L || b == 0L) 0L else a / gcd(a, b) * b
 
 /**
- * Raises this Long to the given [power] (which must be non-negative) using binary exponentiation.
+ * Raises this Long to the given [power] (which must be non-negative) using
+ * [binary exponentiation](https://en.wikipedia.org/wiki/Exponentiation_by_squaring), in O(log n) time.
  *
- * This function uses the fast binary exponentiation algorithm
- * (also known as [exponentiation by squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring)),
- * which computes the result in O(log n) time, where n is the exponent.
- *
- * **Warning**: This function does not check for overflow. For large bases or exponents,
- * the result may overflow and wrap around.
+ * **Warning**: does not check for overflow — large values wrap around.
  *
  * @see pow overload with modulo parameter for modular exponentiation
  *
@@ -65,12 +55,9 @@ public infix fun Long.pow(power: Long): Long {
 }
 
 /**
- * Raises this Long to the given [power] (which must be non-negative), modulo [modulo] (which must be
- * positive), using binary exponentiation; the result is in the range `[0, modulo)`.
- *
- * This function uses the fast binary exponentiation algorithm with modular arithmetic,
- * computing the result in O(log n) time, where n is the exponent. The modulo operation
- * is applied at each step to prevent overflow.
+ * Raises this Long to the given [power] (non-negative) modulo [modulo] (positive), using binary
+ * exponentiation in O(log n) time; the result is in `[0, modulo)`. The modulus is applied at each
+ * step to avoid overflow.
  *
  * @see pow overload without a modulo parameter for regular exponentiation
  *

--- a/src/commonMain/kotlin/kodvent/strings/PrefixFunction.kt
+++ b/src/commonMain/kotlin/kodvent/strings/PrefixFunction.kt
@@ -8,17 +8,10 @@
 package kodvent.strings
 
 /**
- * Computes the prefix function for this character sequence, returning an array whose i-th element is
- * the length of the longest proper prefix of `this[0..i]` that is also a suffix of `this[0..i]`.
- *
- * The prefix function π_i is defined as the length of the longest proper prefix
- * of the substring `s[0..i]` that is also a suffix of this substring.
- * This is a fundamental component of the
- * [Knuth-Morris-Pratt (KMP) string matching algorithm](https://cp-algorithms.com/string/prefix-function.html).
- *
- * ## Complexity
- * - Time: O(n) where n is the length of the character sequence
- * - Space: O(n) for the result array
+ * Computes the [prefix function](https://cp-algorithms.com/string/prefix-function.html) of this
+ * character sequence: an array whose i-th element is the length of the longest proper prefix of
+ * `this[0..i]` that is also a suffix of it. A building block of the Knuth-Morris-Pratt algorithm.
+ * O(n) time and space.
  *
  * @sample samples.PrefixFunctionAndKMPSamples.prefixFunctionBasicUsage
  * @sample samples.PrefixFunctionAndKMPSamples.prefixFunctionUnderstandingTheResult
@@ -28,17 +21,9 @@ package kodvent.strings
 public fun CharSequence.prefixFunction(): IntArray = prefixFunction(length, ::get)
 
 /**
- * Computes the prefix function for a generic sequence of [length] elements of type [T], where [at]
- * returns the element at a given index. Returns an array whose i-th element is the length of the
- * longest proper prefix that is also a suffix for the subsequence `[0..i]`.
- *
- * This is a generalized version of the prefix function that works with any type of sequence
- * where elements can be accessed by index and compared for equality. The prefix function π_i
- * represents the length of the longest proper prefix that is also a suffix for the sequence up to position i.
- *
- * ## Complexity
- * - Time: O(n) where n is the length parameter
- * - Space: O(n) for the result array
+ * Generic [prefix function](https://cp-algorithms.com/string/prefix-function.html) over [length] elements
+ * of type [T] accessed by index via [at] (compared with `==`). Returns an array whose i-th element is the
+ * length of the longest proper prefix that is also a suffix of the subsequence `[0..i]`. O(n) time and space.
  *
  * @sample samples.PrefixFunctionAndKMPSamples.genericPrefixFunctionWithIntegers
  * @sample samples.PrefixFunctionAndKMPSamples.genericPrefixFunctionWithCustomObjects
@@ -56,17 +41,9 @@ public inline fun <T> prefixFunction(length: Int, at: (Int) -> T): IntArray {
 }
 
 /**
- * Finds all starting indices where the [needle] substring occurs in this character sequence.
- *
- * This function uses the
- * [Knuth-Morris-Pratt (KMP) algorithm](https://cp-algorithms.com/string/prefix-function.html)
- * to efficiently find all occurrences of the needle string within the text.
- * It concatenates the needle, the [delimiter] character, and the text, then uses the prefix function to
- * identify matches. The [delimiter] (default `'#'`) must not appear in either the needle or the text.
- *
- * ## Complexity
- * - Time: O(n + m) where n is the length of this sequence and m is the length of the needle
- * - Space: O(n + m) for the concatenated string and prefix array
+ * Returns the starting indices of every occurrence of [needle] in this character sequence, using the
+ * Knuth-Morris-Pratt algorithm (via the prefix function) in O(n + m) time. The [delimiter] (default `'#'`)
+ * is used internally and must not appear in [needle] or in this sequence.
  *
  * @throws IllegalArgumentException if the delimiter appears in the needle or in this text
  *


### PR DESCRIPTION
Follow-up to #37: the KDoc was still verbose, repeating the same boilerplate across overloads — the lower/upper-bound explanation in all eight `Collections` functions, the Ackermann complexity line in three `DisjointSetUnion` methods, plus restated summaries in `SegmentTree` and `PrefixFunction`.

This keeps every fact (return semantics, constraints, complexity, `null` ordering, the non-negative-insertion-point note) and drops the repetition and filler. Docs only, no API or behavior change.
